### PR TITLE
RIF-16 reposition and restylize ReachOut button

### DIFF
--- a/src/pages/Home/components/Donate/Donate.js
+++ b/src/pages/Home/components/Donate/Donate.js
@@ -7,6 +7,7 @@ const Donate = () => {
   return (
     // TODO This can be maped.
     <Stack spacing={3} sx={{textAlign: 'left', maxWidth: '160px'}}>
+      <ReachOut />
       <BuyMeACoffeeButton />
       <Divider >
         <Typography variant="p">Made by</Typography>
@@ -34,7 +35,7 @@ const Donate = () => {
         </a>
       </Stack>
       <Divider />
-      <ReachOut />
+      
     </Stack>
   );
 }

--- a/src/pages/Home/components/Donate/ReachOut.js
+++ b/src/pages/Home/components/Donate/ReachOut.js
@@ -1,14 +1,43 @@
-import { Button, Stack } from "@mui/material";
+import { Stack, useTheme } from "@mui/material";
+import Button from "@mui/material/Button";
+import EmailIcon from "@mui/icons-material/Email";
+
 const ReachOut = () => {
+  const theme = useTheme();
+
   return (
     <Stack>
-      <a href="https://airtable.com/shreuEqEiILbGu7NN" target="_blank" rel="noreferrer" style={{textDecoration: 'none', width: '100%', maxWidth: '250px',margin: '0px auto'}}>
-        <Button variant="outlined" size="large" style={{width: '100%'}}>
-          contact
+      <a
+        href="https://airtable.com/shreuEqEiILbGu7NN"
+        target="_blank"
+        rel="noreferrer"
+        style={{
+          textDecoration: "none",
+          width: "100%",
+          maxWidth: "250px",
+          margin: "0px auto",
+        }}
+      >
+        <Button
+          startIcon={<EmailIcon />}
+          variant="outlined"
+          size="large"
+          style={{ width: "100%" }}
+          sx={{
+            backgroundColor: theme.palette.primary.main,
+            color: theme.palette.background.default,
+            fontWeight: "bold",
+            justifyContent: "left",
+            textTransform: "none",
+            my: 0.5,
+            px: 1.5,
+          }}
+        >
+          Contact
         </Button>
       </a>
     </Stack>
   );
-}
- 
+};
+
 export default ReachOut;


### PR DESCRIPTION
-move **Contact** button from beneath Dev Team Names, place above **Buy Me A Coffee link**
-pass `useTheme` props to Donate > **ReachOut.js**
-add `sx` properties to **Contact** button to reverse color pattern
-add MUI `EmailIcon` to **Contact** Button
-add `sx` properties from **Collection** button to **Contact** `fontWeight`, `justifyContent`, `textTransform`, `my`, `px`