### PR TITLE
Rif 17 feature contact form

### DIFF
--- a/src/pages/Home/components/ContactForm/ContactButton.js
+++ b/src/pages/Home/components/ContactForm/ContactButton.js
@@ -1,5 +1,7 @@
 import { Button, Stack } from "@mui/material";
-const ReachOut = () => {
+
+// TODO: Plug in ContactForm component in place of Airtable link
+const ContactButton = () => {
   return (
     <Stack>
       <a href="https://airtable.com/shreuEqEiILbGu7NN" target="_blank" rel="noreferrer" style={{textDecoration: 'none', width: '100%', maxWidth: '250px',margin: '0px auto'}}>
@@ -11,4 +13,4 @@ const ReachOut = () => {
   );
 }
  
-export default ReachOut;
+export default ContactButton;

--- a/src/pages/Home/components/ContactForm/ContactForm.js
+++ b/src/pages/Home/components/ContactForm/ContactForm.js
@@ -1,0 +1,95 @@
+// Services
+import { useState, useContext } from "react";
+import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
+import { useForm } from "react-hook-form";
+
+// Components
+import { Button, TextField, Select, MenuItem, Stack } from "@mui/material";
+
+// TODO: RYAN - Revamp ContactForm function for current applicable fields below. Initial Stub-up is based off of the LoginForm component, thus potentially not all hooks are applicable to the ContactForm component. Please review and adjust accordingly.
+const ContactForm = () => {
+  const { register, handleSubmit } = useForm();
+  const [errorMessage, setErrorMessage] = useState();
+  const { authenticate } = useContext(UserContext);
+  const [waitingForResponse, setWaitingForResponse] = useState(false);
+  /**
+   * Handles Email form submit.
+   * @param {{Email}} data - the form data
+   */
+  const onSubmit = (data) => {
+    setErrorMessage(null);
+    setWaitingForResponse(true);
+    authenticate(data["Email"])
+      .then((user) => {
+        setWaitingForResponse(false);
+      })
+      .catch((error) => {
+        setWaitingForResponse(false);
+        console.error("Incorrect Email: ", error);
+        if (error.code === "NotAuthorizedException") {
+          setErrorMessage("* Incorrect email, dude!");
+        } else {
+          setErrorMessage("* Something went wrong, sorry! Try again, dude!");
+        }
+      });
+  };
+
+  // TODO adjust handleChange function to update the messageType state
+  const handleChange = (event) => {
+    event.preventDefault();
+    const action = {
+      type: "updateMessageType",
+      name: event.target.value,
+    };
+    // dispatch(action);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} data-testid="ContactForm">
+      <Stack spacing={2}>
+        <TextField
+          required
+          type="text"
+          variant="outlined"
+          placeholder="Name"
+          {...register("Name", { required: true })}
+          aria-label="Name"
+        />
+        <TextField
+          required
+          type="email"
+          variant="outlined"
+          placeholder="Email"
+          {...register("Email", { required: true })}
+          aria-label="Email"
+        />
+        <Select
+          labelId="message-type-select-label"
+          value={""}
+          label="Message Type"
+          onChange={handleChange}
+        >
+          <MenuItem value={"Feedback"}>Feedback</MenuItem>
+          <MenuItem value={"Request Help"}>Request Help</MenuItem>
+          <MenuItem value={"Report a Bug"}>Report a Bug</MenuItem>
+          <MenuItem value={"Request a Feature"}>Request a Feature</MenuItem>
+          <MenuItem value={"Other"}>Other</MenuItem>
+        </Select>
+        <TextField
+          required
+          type="text"
+          variant="outlined"
+          placeholder=""
+          {...register("Message", { required: true })}
+          aria-label="Message"
+        />
+        {errorMessage && <p style={{ color: "red" }}>{errorMessage}</p>}
+        <Button variant="contained" type="submit" disabled={waitingForResponse}>
+          <span data-testid="send-button">Send</span>
+        </Button>
+      </Stack>
+    </form>
+  );
+};
+
+export default ContactForm;

--- a/src/pages/Home/components/Donate/Donate.js
+++ b/src/pages/Home/components/Donate/Donate.js
@@ -2,7 +2,7 @@ import { Typography } from "@mui/material";
 import { Box, Stack, Divider } from "@mui/material";
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import BuyMeACoffeeButton from "../HeaderLinks/BuyMeACofeeButton/BuyMeACoffeeButton";
-import ReachOut from "./ReachOut";
+import ContactButton from "../ContactForm/ContactButton";
 const Donate = () => {
   return (
     // TODO This can be maped.
@@ -34,7 +34,7 @@ const Donate = () => {
         </a>
       </Stack>
       <Divider />
-      <ReachOut />
+      <ContactButton />
     </Stack>
   );
 }

--- a/src/pages/Home/components/Donate/DonateMobile.js
+++ b/src/pages/Home/components/Donate/DonateMobile.js
@@ -2,7 +2,7 @@ import {  Typography } from "@mui/material";
 import { Box, Stack, Divider, useTheme } from "@mui/material";
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import BuyMeACoffeeButton from "../HeaderLinks/BuyMeACofeeButton/BuyMeACoffeeButton";
-import ReachOut from "./ReachOut";
+import ContactButton from "../ContactForm/ContactButton";
 const DonateMobile = () => {
   const theme = useTheme();
 
@@ -45,7 +45,7 @@ const DonateMobile = () => {
         <BuyMeACoffeeButton />
       </Box>
       <Divider />
-      <ReachOut />
+      <ContactButton />
     </Stack>
   );
 }

--- a/src/pages/Home/components/TagBar/TagBar.js
+++ b/src/pages/Home/components/TagBar/TagBar.js
@@ -98,4 +98,4 @@ const TagBar = () => {
   );
 }
 
-export default TagBar;
+export default TagBar; 


### PR DESCRIPTION
Previously had an issue creating a PR, now solved with credentials updated, thanks @RyanSUP !

**ReachOut.js** file has been renamed to **ContactButton.js**, nested within a new **ContactForm** component folder

Fields for Contact Form:
- Name - `string`
- Email - `string` with email validation
- Message Type - `enum`
- Message - `string`

used LoginForm.js as initial component template for ContactForm.js, refactor Text Fields to Name, Email, etc.

Imported [Select](https://mui.com/material-ui/react-select/) and [MenuItem](https://mui.com/material-ui/api/menu-item/) from MUI for Dropdown enum. handleChange function needs to be adjusted for this. 

I need some help refactoring the form accordingly in terms of appropriate Hooks/data calls. That can be my task or Ryan's once he sets up whatever is needed for AWS's end.

**Needed for Backend request**:
- Format fields into Email contents
- Send email to designated address (i.e. info@riffin.io) from inputted address (i.e. helplessuser@aol.net)
- Potentially, auto-reply to sender
- Potentially needs email service from third-party (i.e. MailChimp)